### PR TITLE
fovsenscalc: use argparse to add option names and simplify the code

### DIFF
--- a/fovsenscalc
+++ b/fovsenscalc
@@ -12,36 +12,19 @@
 #   My little commie <3
 #===============================================================================
 
+"""
+OpenArena FOV sensitivity calculator.
+
+Calculate mouse sensitivity values after changing `cg_fov`
+that will keep the exact same "feel" of the mouse.
+
+It is recommended scale by adjusting the cvars `m_yaw` and `m_pitch`, but
+`sensitivity` and `cl_mouseaccel` can also be adjusted instead.
+"""
+
+import argparse
 import sys
 import math
-
-def usage():
-    sys.stderr.write("""\
-OpenArena FOV sensitivity calculator
-====================================
-
-Usage:
-  %s <new_fov> <base_fov> [number]...
-
-Options:
-  <new_fov> - The new value of new `cg_fov`.
-  <old_fov> - The old value of `cg_fov`.
-  [number]... - The sensitivity number(s) to scale with the fov change. It is
-    recommended scale by adjusting the cvars `m_yaw` and `m_pitch`, but
-    `sensitivity` and `cl_mouseaccel` can also be adjusted instead. If no number
-    is specified the program will print out the ratio between the new
-    sensitivity and the old sensitivity
-
-Example:
-  How to get the new m_yaw/m_pitch values when switching to 22.5 fov from 90 fov
-  and 0.022 m_yaw/m_pitch?
-    %s 22.5 90 0.022
-""" % (sys.argv[0], sys.argv[0]))
-    sys.exit(1)
-
-def error(msg):
-    sys.stderr.write(msg)
-    sys.exit(1)
 
 def sens_ratio(new_fov, old_fov):
     new_fov = math.radians(new_fov)
@@ -49,29 +32,39 @@ def sens_ratio(new_fov, old_fov):
     return math.tan(new_fov / 2) / math.tan(old_fov / 2)
 
 def main():
-    if len(sys.argv) < 3:
-        usage()
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        '--new-fov',
+        help='New cg_fov value',
+        type=float,
+        required=True,
+    )
+    parser.add_argument(
+        '--old-fov',
+        help='Old cg_fov value',
+        type=float,
+        required=True,
+    )
+    parser.add_argument(
+        '--values-to-scale',
+        help='The sensitivity number(s) to scale with the fov change',
+        dest='values_to_scale',
+        default=[],
+        nargs='+',
+        type=float,
+    )
+    args = parser.parse_args()
 
-    try:
-        new_fov = float(sys.argv[1])
-    except:
-        error("Invalid number argument: %s" % sys.argv[1])
-
-    try:
-        old_fov = float(sys.argv[2])
-    except:
-        error("Invalid number argument: %s" % sys.argv[2])
-
-    c = sens_ratio(new_fov, old_fov)
-
-    if (len(sys.argv) == 3):
+    c = sens_ratio(args.new_fov, args.old_fov)
+    if (not len(args.values_to_scale)):
+        # No sensitivity number(s) to scale, print only ratio.
         print(c)
     else:
-        for v in sys.argv[3:]:
-            try:
-                print(c * float(v))
-            except:
-                error("Invalid number argument: %s" % v)
+        for v in args.values_to_scale:
+            print(c * float(v))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
It makes the usage much more flexible when you don't have to think
about option values order. Moreover, you don't need to write
comments and examples about it. :)